### PR TITLE
[환경 설정] custom route 추가 및 alias 절대 경로 지정

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,16 @@
   "dependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
+    "@types/js-cookie": "^3.0.1",
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.11",
+    "js-cookie": "^3.0.1",
     "path": "^0.12.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-hook-form": "^7.29.0",
     "react-query": "^3.34.19",
-    "recoil": "^0.7.0",
+    "react-router-dom": "^6.3.0",
     "ts-loader": "^9.2.6",
     "typescript": "^4.5.5"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,74 @@
-import React from "react";
+import React, { Suspense, lazy } from "react";
+import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+
+import PrivateRoute from "@routes/private";
+import PublicRoute from "@routes/public";
+import AdminRoute from "./routes/admin";
+
+import Spinner from "@atoms/spinner";
+import {
+  MAIN_URL,
+  MYPAGE_URL,
+  SIGNIN_URL,
+  SIGNUP_URL,
+  ADMIN_URL,
+} from "@constants/index";
+
+const MyPage = lazy(() => import("@pages/myPage"));
+const Main = lazy(() => import("@pages/main"));
+const SignIn = lazy(() => import("@pages/signIn"));
+const SignUp = lazy(() => import("@pages/signUp"));
+const Admin = lazy(() => import("@pages/admin"));
 
 function App() {
-  return <div></div>;
+  return (
+    <Suspense fallback={<Spinner />}>
+      <Router>
+        <Routes>
+          <Route
+            path={MYPAGE_URL}
+            element={
+              <PrivateRoute>
+                <MyPage />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path={MAIN_URL}
+            element={
+              <PublicRoute>
+                <Main />
+              </PublicRoute>
+            }
+          />
+          <Route
+            path={SIGNIN_URL}
+            element={
+              <PublicRoute>
+                <SignIn />
+              </PublicRoute>
+            }
+          />
+          <Route
+            path={SIGNUP_URL}
+            element={
+              <PublicRoute>
+                <SignUp />
+              </PublicRoute>
+            }
+          />
+          <Route
+            path={ADMIN_URL}
+            element={
+              <AdminRoute>
+                <Admin />
+              </AdminRoute>
+            }
+          />
+        </Routes>
+      </Router>
+    </Suspense>
+  );
 }
 
 export default App;

--- a/src/components/atoms/spinner/index.tsx
+++ b/src/components/atoms/spinner/index.tsx
@@ -1,0 +1,5 @@
+const Spinner = () => {
+  return <></>;
+};
+
+export default Spinner;

--- a/src/components/pages/admin/index.tsx
+++ b/src/components/pages/admin/index.tsx
@@ -1,0 +1,5 @@
+const Admin = () => {
+  return <></>;
+};
+
+export default Admin;

--- a/src/components/pages/main/index.tsx
+++ b/src/components/pages/main/index.tsx
@@ -1,0 +1,5 @@
+const Main = () => {
+  return <></>;
+};
+
+export default Main;

--- a/src/components/pages/myPage/index.tsx
+++ b/src/components/pages/myPage/index.tsx
@@ -1,0 +1,5 @@
+const MyPage = () => {
+  return <></>;
+};
+
+export default MyPage;

--- a/src/components/pages/signUp/index.tsx
+++ b/src/components/pages/signUp/index.tsx
@@ -1,0 +1,5 @@
+const SignUp = () => {
+  return <></>;
+};
+
+export default SignUp;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,23 @@
+// url
+export const MAIN_URL = "/";
+
+export const SIGNIN_URL = "/signIn";
+
+export const SIGNUP_URL = "/signUp";
+
+export const MYPAGE_URL = "/myPage";
+
+export const ADMIN_URL = "/admin";
+
+export const INPUT_DATA = {
+  id: {
+    type: "text",
+    placeholder: "아이디",
+    content: "아이디",
+  },
+  password: {
+    type: "password",
+    placeholder: "비밀번호",
+    content: "비밀번호",
+  },
+};

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -1,0 +1,12 @@
+import { ReactElement } from "react";
+import { Navigate } from "react-router-dom";
+
+interface Props {
+  children: ReactElement;
+}
+
+const AdminRoute = ({ children: Component }: Props) => {
+  const admin = true;
+  return admin ? Component : <Navigate to="/" />;
+};
+export default AdminRoute;

--- a/src/routes/private.tsx
+++ b/src/routes/private.tsx
@@ -1,0 +1,12 @@
+import { ReactElement } from "react";
+import { Navigate } from "react-router-dom";
+import isLogin from "@utils/isLogin";
+
+interface Props {
+  children: ReactElement;
+}
+
+const PrivateRoute = ({ children: Component }: Props) => {
+  return isLogin() ? Component : <Navigate to="/signIn" />;
+};
+export default PrivateRoute;

--- a/src/routes/public.tsx
+++ b/src/routes/public.tsx
@@ -1,0 +1,12 @@
+import { ReactElement } from "react";
+import { Navigate } from "react-router-dom";
+import isLogin from "@utils/isLogin";
+
+interface Props {
+  children: ReactElement;
+}
+
+const PublicRoute = ({ children: Component }: Props) => {
+  return isLogin() ? <Navigate to="/" /> : Component;
+};
+export default PublicRoute;

--- a/src/utils/isLogin.ts
+++ b/src/utils/isLogin.ts
@@ -1,0 +1,3 @@
+import Cookies from "js-cookie";
+const isLogin = () => !!Cookies.get("token");
+export default isLogin;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
       "DOM.Iterable",
       "ESNext"
     ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-    "jsx": "react" /* Specify what JSX code is generated. */,
+    "jsx": "react-jsx" /* Specify what JSX code is generated. */,
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
@@ -31,8 +31,17 @@
     "module": "commonjs" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
+    "paths": {
+      "@src/*": ["src/*"],
+      "@pages/*": ["src/components/pages/*"],
+      "@atoms/*": ["src/components/atoms/*"],
+      "@organisms/*": ["src/components/organisms/*"],
+      "@routes/*": ["src/routes/*"],
+      "@utils/*": ["src/utils/*"],
+      "@constants/*": ["src/constants/*"],
+      "@styles/*": ["src/styles/*"]
+    } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,16 @@ module.exports = {
 
   resolve: {
     extensions: [".js", ".jsx", ".ts", ".tsx"],
+    alias: {
+      "@src": path.resolve(__dirname, "src"),
+      "@atoms": path.resolve(__dirname, "src/components/atoms"),
+      "@organisms": path.resolve(__dirname, "src/components/organisms"),
+      "@pages": path.resolve(__dirname, "src/components/pages"),
+      "@routes": path.resolve(__dirname, "src/routes"),
+      "@utils": path.resolve(__dirname, "src/utils"),
+      "@constants": path.resolve(__dirname, "src/constants"),
+      "@styles": path.resolve(__dirname, "src/styles"),
+    },
   },
 
   module: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -932,7 +932,7 @@
     "@babel/helper-validator-option" "^7.16.7"
     "@babel/plugin-transform-typescript" "^7.16.7"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
   integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
@@ -1210,6 +1210,11 @@
   integrity sha512-5kPLG5BKpWYkw/LVOGWpiq3nEVqxiN32rTgI53Sk12/xHFQ2rG3ehI9IO+O3W2QoKeyB92dJkoka8SUm6BX1pA==
   dependencies:
     "@types/node" "*"
+
+"@types/js-cookie@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.1.tgz#04aa743e2e0a85a22ee9aa61f6591a8bc19b5d68"
+  integrity sha512-7wg/8gfHltklehP+oyJnZrz9XBuX5ZPP4zB6UsI84utdlkRYLnOm2HfpLXazTwZA+fpGn0ir8tGNgVnMEleBGQ==
 
 "@types/json-schema@*", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.9"
@@ -2488,11 +2493,6 @@ graceful-fs@^4.1.2, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
   integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
-hamt_plus@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
-  integrity sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE=
-
 handle-thing@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
@@ -2531,6 +2531,13 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+history@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
+  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
 
 hoist-non-react-statics@^3.3.1:
   version "3.3.2"
@@ -2836,6 +2843,11 @@ jest-worker@^27.4.5:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
+
+js-cookie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
+  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
 
 js-sha3@0.8.0:
   version "0.8.0"
@@ -3422,6 +3434,11 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-hook-form@^7.29.0:
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.29.0.tgz#5e7e41a483b70731720966ed8be52163ea1fecf1"
+  integrity sha512-NcJqWRF6el5HMW30fqZRt27s+lorvlCCDbTpAyHoodQeYWXgQCvZJJQLC1kRMKdrJknVH0NIg3At6TUzlZJFOQ==
+
 react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -3435,6 +3452,21 @@ react-query@^3.34.19:
     "@babel/runtime" "^7.5.5"
     broadcast-channel "^3.4.1"
     match-sorter "^6.0.2"
+
+react-router-dom@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
+  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
+  dependencies:
+    history "^5.2.0"
+    react-router "6.3.0"
+
+react-router@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+  dependencies:
+    history "^5.2.0"
 
 react@^17.0.2:
   version "17.0.2"
@@ -3479,13 +3511,6 @@ rechoir@^0.7.0:
   integrity sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==
   dependencies:
     resolve "^1.9.0"
-
-recoil@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.0.tgz#de19c6fb9816c172b0dae92cf8fe94c2c90a23ab"
-  integrity sha512-NYG79ZciSILFIu6Zo3aoqPOIU0Ok+dIwA9DM4NdxIx0tKXKenAZWxsalyRQyGVfxR3cVynsgVu7XCAdKNa957A==
-  dependencies:
-    hamt_plus "1.0.2"
 
 regenerate-unicode-properties@^10.0.1:
   version "10.0.1"


### PR DESCRIPTION
## 📐구현한 사항
- admin, private, public route 분리
<img width="152" alt="스크린샷 2022-04-18 오후 4 56 51" src="https://user-images.githubusercontent.com/38166372/163776452-3be3053e-1970-48b1-ad1c-72f21bd4c24d.png">

- alias 설정
<img width="509" alt="스크린샷 2022-04-18 오후 4 56 22" src="https://user-images.githubusercontent.com/38166372/163776380-417e2cde-19ae-4f42-b77f-ff766e0798e8.png">

## 📋논의 할 사항
- 아직  관리자의 구분과 로그인 인증에 대한 로직을 작성하지 못하였습니다. 추후 추가 할 예정입니다.
- 현재 아토믹 구조중 atoms, organisms, pages 3계층만을 사용하여 구조를 구성하였습니다.
